### PR TITLE
subpackages.md: Usage note regarding build types and configurations

### DIFF
--- a/docs/dub-reference/subpackages.md
+++ b/docs/dub-reference/subpackages.md
@@ -50,6 +50,7 @@ Specified build types and configurations (e.g., via the command-line
 interface) are applied to the sub-package, and are taken from the sub-package recipe.
 For example, executing `dub build :mylibrary -c experimental`, the `experimental`
 configuration must exist in the sub-package recipe.
+If a build type exists in both packages, both will be applied.
 
 ## Declaration
 

--- a/docs/dub-reference/subpackages.md
+++ b/docs/dub-reference/subpackages.md
@@ -65,9 +65,9 @@ Following the same example, configurations can also be referenced via recipes:
 
     ```json
     {
-    	"subConfigurations": {
-		    ":mylibrary": "experimental"
-	    }
+        "subConfigurations": {
+            ":mylibrary": "experimental"
+        }
     }
     ```
 

--- a/docs/dub-reference/subpackages.md
+++ b/docs/dub-reference/subpackages.md
@@ -48,9 +48,28 @@ and will be visible for when the sub-package is used as dependency.
 
 Specified build types and configurations (e.g., via the command-line
 interface) are applied to the sub-package, and are taken from the sub-package recipe.
-For example, executing `dub build :mylibrary -c experimental`, the `experimental`
-configuration must exist in the sub-package recipe.
 If a build type exists in both packages, both will be applied.
+
+For example, executing `dub build :mylibrary -c experimental`,
+the `experimental` configuration must exist in the sub-package recipe.
+
+Following the same example, configurations can also be referenced via recipes:
+
+=== "dub.sdl"
+
+    ```sdl
+    subConfiguration ":mylibrary" "experimental"
+    ```
+
+=== "dub.json"
+
+    ```json
+    {
+    	"subConfigurations": {
+		    ":mylibrary": "experimental"
+	    }
+    }
+    ```
 
 ## Declaration
 

--- a/docs/dub-reference/subpackages.md
+++ b/docs/dub-reference/subpackages.md
@@ -46,6 +46,11 @@ For example, with a root package named `package` with a `mylibrary` sub-package,
 a `Have_package_mylibrary` version will be automatically defined by DUB,
 and will be visible for when the sub-package is used as dependency.
 
+Specified build types and configurations (e.g., via the command-line
+interface) are applied to the sub-package, and are taken from the sub-package recipe.
+For example, executing `dub build :mylibrary -c experimental`, the `experimental`
+configuration must exist in the sub-package recipe.
+
 ## Declaration
 
 Sub-packages can be declared entirely within the main recipe, or by a


### PR DESCRIPTION
I forgot to add the importance that specified settings, like `-b|--build=` and `-c|--config`, have when using sub-packages, as these specifically target the sub-package mentioned, and hopefully increase the notion that the build settings are really isolated and not shared across packages.