### PR TITLE
Fix: Move frontpage to top-level navigation for easier access

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,8 +71,8 @@ extra_css:
   - stylesheets/extra.css
 
 nav:
+  - "Intro to DUB": index.md  # Moved to top level
   - "Getting Started":
-    - "Intro to DUB": index.md
     - getting-started/install.md
     - getting-started/first-steps.md
   - "DUB Guide":


### PR DESCRIPTION
### 📝 Description
- Moved the frontpage (`Intro to DUB`) to the top-level navigation.
- This change eliminates the unnecessary nesting, making it easier to access the full documentation without multiple back clicks.
- Fixed navigation behavior that caused confusion, especially on mobile devices.

### 📱 Mobile Improvement
- Previously, navigation started at the second-level, making it cumbersome on mobile.
- Now, the homepage is directly accessible, eliminating the need to click the back button multiple times.

---

### 🎨 **Proposed New Design**
I have also designed an improved version of the page with better navigation.  
✅ If you like it, I would be happy to proceed with that design as a future enhancement.
![image](https://github.com/user-attachments/assets/e63aed3c-9093-4e59-9fe9-c8db7d406ed3)



### 📂 **Files Changed:**
- `mkdocs.yml`

---

### 🔗 **Reference Issue:**
Closes #88
