### PR TITLE
darkmode added

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ The [CLI](cli-reference/dub.md) can be used to
 - test projects ([dub test](cli-reference/dub-test.md))
 
 To see how to obtain dub, **go to the next page by pressing the button below**.
+<button id="theme-toggle">Toggle Dark Mode</button>
 
 <!-- old docs anchors for index page, all link to first steps -->
 <a id="own-projects"></a>
@@ -20,3 +21,7 @@ To see how to obtain dub, **go to the next page by pressing the button below**.
 ## Starting a new project
 
 You can also skip ahead to [First steps](getting-started/first-steps.md) if you already have dub installed.
+
+
+<!-- Include the darkmode.js script -->
+<script src="/js/darkmode.js"></script>

--- a/docs/js/darkmode.js
+++ b/docs/js/darkmode.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const themeToggle = document.getElementById('theme-toggle');
+    const body = document.body;
+
+    // Check if dark mode was previously set
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme === 'dark') {
+        body.classList.add('dark-theme');
+    }
+
+    // Event listener for toggling dark mode
+    themeToggle.addEventListener('click', function() {
+        body.classList.toggle('dark-theme');
+
+        // Save the user's theme preference in local storage
+        if (body.classList.contains('dark-theme')) {
+            localStorage.setItem('theme', 'dark');
+        } else {
+            localStorage.setItem('theme', 'light');
+        }
+    });
+});

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -202,7 +202,22 @@ body:not([data-md-color-scheme="slate"]) .md-search__input::placeholder {
     mask-image: var(--md-admonition-icon--cli);
 }
 
+
+/* darkmode */
+/* Default (light) theme */
+/* body {
+    background-color: #fff;
+    color: #000;
+} */
+
+/* Dark theme */
+body.dark-theme {
+    background-color: #121212;
+    color: #fff;
+}
+
 /* install page OS icons */
+
 
 div.install {
     padding-left: 70px;


### PR DESCRIPTION
This PR introduces a dark mode toggle for the documentation site, enhancing the user experience by allowing users to switch between light and dark themes. The following changes have been made:

JavaScript: Added a darkmode.js file in the docs/js/ directory to handle the toggle functionality and save the theme preference in local storage.

CSS: Updated extra.css to include styles for dark mode and its transitions.

Markdown: Modified the index.md file to include an introductory section for the dark mode toggle, enabling users to switch the theme from the documentation interface.

Files Changed:
docs/index.md: Added a dark mode toggle in the introductory section of the page.

docs/js/darkmode.js: JavaScript for switching between light and dark themes.

docs/stylesheets/extra.css: CSS styles for dark mode.

after changes:

https://github.com/user-attachments/assets/476f1c10-a19d-44e1-8986-77fa9919586b

