### PR TITLE
Fix markup for `dub help`

### DIFF
--- a/docs/getting-started/first-steps.md
+++ b/docs/getting-started/first-steps.md
@@ -73,7 +73,7 @@ Execute [`dub build`](../cli-reference/dub-build.md) to build your project, [`du
     Edit source/app.d to start your project.
     </pre>
 
-See the [command line interface documentation](../cli-reference/dub.md), or run [dub --help and dub <command> --help](../cli-reference/dub.md) for more information.
+See the [command line interface documentation](../cli-reference/dub.md), or run [`dub --help`](../cli-reference/dub.md) and [`dub <command> --help`](../cli-reference/dub.md) for more information.
 
 ## Adding a dependency
 


### PR DESCRIPTION
This currently doesn't render correctly:

<img src="https://github.com/user-attachments/assets/bf23f50a-abcc-4727-8450-47e6a025621a" width="700">
